### PR TITLE
Update process to share design doc with mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The design process for changes to M3DB is loosely modeled on the [proposal proce
   - The design doc should be linked from the opened GitHub issue.
   - The design doc should only allow edit access to authors of the document.
   - Do not create the document from a corporate G Suite account, if you wish to edit from a corporate G Suite account then first create the document from a personal Google account and grant edit access to your corporate G Suite account.
-  - Comment access should be accessible by the public, make sure this is the case by clicking "Share" and "Get shareable link" ensuring to select "Anyone with the link can comment".
+  - Comment access should be granted explicitly to [m3db@googlegroups.com](mailto:m3db@googlegroups.com) so that users viewing the document display under their account names rather than anonymous users.
+  - Comment access should also be accessible by the public, make sure this is the case by clicking "Share" and "Get shareable link" ensuring to select "Anyone with the link can comment".
   
 
 - Once comments and revisions on the design doc wind down, there is a final discussion about the proposal.


### PR DESCRIPTION
Without explicitly sharing the design doc with the mailing list, users viewing the document will show up as anonymous users when viewing the Google Doc.

This will mitigate this issue.  

More information here:
https://support.google.com/docs/answer/2494888?hl=en